### PR TITLE
Cambio cálculo IVA

### DIFF
--- a/propuesta.md
+++ b/propuesta.md
@@ -41,9 +41,9 @@ Todos los precios anunciados al público deberán incluir ya el IVA correspondie
 
 Por ejemplo:
 * Supongamos una tasa de IVA del 10%.
-* Persona A le vende un producto por $100 pesos a Persona B.
-* La Persona B hace un pago por $100 pesos a la Persona A.
-* Persona A recibe $90 pesos, el banco retiene los $10 pesos y los paga al SAT.
+* Persona A quiere recibir 100 pesos por la venta de un producto a la Persona B.
+* La Persona B hace un pago por 110 pesos a la Persona A (100 del producto + 10 del IVA).
+* Persona A recibe 100 pesos, el banco retiene los 10 pesos y los paga al SAT.
 
 Esto evita que la gente tenga que calcular y pagar impuestos, ya que el banco los recauda automáticamente con cada transacción.
 


### PR DESCRIPTION
@mrchapp comenta que:
>La gente quiere $100 pesos y eso va a querer cobrar, así que son $100 ("más IVA").

Creo que las dos opciones son viables, yo lo puse así porque me choca que me den precios sin IVA y veo que actualmente la gente batalla para desglosar el IVA (dividiendo entre 1+IVA), pero supongo que también van a batallar para calcular el precio de venta para que ellos reciban 100 pesos (tendrían que dividir entre 1-IVA).

Me hace sentido el punto y la gente está familiarizada con el esquema actual.